### PR TITLE
Adding support for HACS

### DIFF
--- a/.devcontainer/sample_configuration.yaml
+++ b/.devcontainer/sample_configuration.yaml
@@ -1,0 +1,10 @@
+---
+default_config:
+logger:
+  default: info
+  logs:
+    amberelectric: debug
+    custom_components.amberelectric: debug
+frontend:
+  themes: !include_dir_merge_named themes
+amberelectric:

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -1,0 +1,44 @@
+
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.6.2
+    hooks:
+      - id: pyupgrade
+        stages: [manual]
+        args:
+          - "--py38-plus"
+
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        stages: [manual]
+        args:
+          - --safe
+          - --quiet
+        files: ^((custom_components|script|tests)/.+)?[^/]+\.py$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v1.17.1
+    hooks:
+      - id: codespell
+        stages: [manual]
+        args:
+          - --quiet-level=2
+          - --ignore-words-list=hass,ba,fo
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-executables-have-shebangs
+        stages: [manual]
+      - id: check-json
+        stages: [manual]
+      - id: requirements-txt-fixer
+        stages: [manual]
+      - id: check-ast
+        stages: [manual]
+      - id: mixed-line-ending
+        stages: [manual]
+        args:
+          - --fix=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_zip_file:
+    name: Prepare release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Get version
+        id: version
+        uses: home-assistant/actions/helpers/version@master
+
+      - name: "Set version number"
+        run: |
+          sed -i '/INTEGRATION_VERSION = /c\INTEGRATION_VERSION = "${{ steps.version.outputs.version }}"' ${{ github.workspace }}/custom_components/amberelectric/const.py
+          python3 ${{ github.workspace }}/manage/update_manifest.py --version ${{ steps.version.outputs.version }}
+
+      # Pack the Amber Electric dir as a zip and upload to the release
+      - name: ZIP Amber Electric Dir
+        run: |
+          cd ${{ github.workspace }}/custom_components/amberelectric
+          zip amberelectric.zip -r ./
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v1-release
+
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/custom_components/amberelectric/amberelectric.zip
+          asset_name: amberelectric.zip
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,59 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate-hassfest:
+    runs-on: ubuntu-latest
+    name: With hassfest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Hassfest validation
+      uses: "home-assistant/actions/hassfest@master"
+
+  validate-hacs:
+    runs-on: ubuntu-latest
+    name: With HACS Action
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: HACS validation
+      uses: hacs/action@main
+      with:
+        category: integration
+        comment: false
+
+  validate-homeassistant:
+    name: With Home Assistant
+    strategy:
+      matrix:
+        channel: [stable, beta, dev]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: 📋 Copy sample configuration for Home Assistant
+        run: |
+          mkdir ./test_configuration
+          cp -f .devcontainer/sample_configuration.yaml ./test_configuration/configuration.yaml
+          cp -r ./custom_components ./test_configuration
+          sed -i 's/#//g' ./test_configuration/configuration.yaml
+
+      - name: 👷 Setup Home Assistant
+        id: homeassistant
+        uses: ludeeus/setup-homeassistant@main
+        with:
+          tag: ${{ matrix.channel }}
+          config-dir: test_configuration

--- a/custom_components/amberelectric/manifest.json
+++ b/custom_components/amberelectric/manifest.json
@@ -3,6 +3,7 @@
     "name": "Amber Electric",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/integrations/amberelectric",
+    "issue_tracker": "https://github.com/madpilot/hass-amber-electric/issues",
     "codeowners": [
         "@madpilot"
     ],

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,11 @@
+{
+    "name": "Amber Electric",
+    "country": "AU",
+    "domains": [
+        "sensor"
+    ],
+    "homeassistant": "2021.7.1",
+    "iot_class": [
+        "Cloud Polling"
+    ]
+}

--- a/info.md
+++ b/info.md
@@ -1,0 +1,28 @@
+{% if installed %}
+
+## Changes as compared to your installed version:
+
+### Breaking Changes
+
+### Changes
+
+### Features
+
+  {% if version_installed.replace("v", "").replace(".","") | int < 1  %}
+- Initial deployment
+  {% endif %}
+
+### Bugfixes
+
+  {% if version_installed.replace("v", "").replace(".","") | int < 1  %}
+- Working version
+  {% endif %}
+
+---
+
+{% else %}
+
+## Connect to the Amber Electric API
+
+Retrieve real time pricing and demand information.
+{% endif %}

--- a/manage/update_manifest.py
+++ b/manage/update_manifest.py
@@ -1,0 +1,26 @@
+
+"""Update the manifest file."""
+import sys
+import json
+import os
+
+
+def update_manifest():
+    """Update the manifest file."""
+    version = "0.0.0"
+    for index, value in enumerate(sys.argv):
+        if value in ["--version", "-V"]:
+            version = sys.argv[index + 1]
+
+    with open(f"{os.getcwd()}/custom_components/amberelectric/manifest.json") as manifestfile:
+        manifest = json.load(manifestfile)
+
+    manifest["version"] = version
+
+    with open(
+        f"{os.getcwd()}/custom_components/amberelectric/manifest.json", "w"
+    ) as manifestfile:
+        manifestfile.write(json.dumps(manifest, indent=4, sort_keys=True))
+
+
+update_manifest()


### PR DESCRIPTION
Will need to be compliant with the [HACS rules](https://hacs.xyz/docs/publish/include/#check-repository) before listing - but at least people can use HACS to install from the repo.