### PR TITLE
Adding Unique ID for Sensors

### DIFF
--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import AmberDataService
 
-from .const import CONF_API_TOKEN, CONF_SITE_ID, LOGGER, DOMAIN
+from .const import CONF_API_TOKEN, CONF_SITE_ID, LOGGER
 from homeassistant.const import ATTR_ATTRIBUTION
 
 ATTRIBUTION = "Data provided by the Amber Electric pricing API"
@@ -44,7 +44,7 @@ class AmberPriceSensor(CoordinatorEntity, SensorEntity):
     @property
     def unique_id(self):
         """Return the unique id of the device"""
-        return "%s_%s_%s_%s" % (DOMAIN, self._platform_name, self._channel_type, "Price")
+        return "%s_%s_%s" % (self._platform_name, self._channel_type, "Price")
 
     @property
     def icon(self):
@@ -105,7 +105,7 @@ class AmberRenewablesSensor(CoordinatorEntity, SensorEntity):
     @property
     def unique_id(self):
         """Return the unique id of the device"""
-        return "%s_%s_%s" % (DOMAIN, self._platform_name, "Renewables")
+        return "%s_%s" % (self._platform_name, "Renewables")
 
     @property
     def icon(self):
@@ -142,7 +142,7 @@ class AmberForecastSensor(CoordinatorEntity, SensorEntity):
     @property
     def unique_id(self):
         """Return the unique id of the device"""
-        return "%s_%s_%s_%s" % (DOMAIN, self._platform_name, self._channel_type, "Forecast")
+        return "%s_%s_%s" % (self._platform_name, self._channel_type, "Forecast")
 
     @property
     def icon(self):
@@ -207,7 +207,7 @@ class AmberPriceSpikeSensor(CoordinatorEntity, SensorEntity):
     @property
     def unique_id(self):
         """Return the unique id of the device"""
-        return "%s_%s_%s" % (DOMAIN, self._platform_name, "PriceSpike")        
+        return "%s_%s" % (self._platform_name, "PriceSpike")        
 
     @property
     def state(self) -> Union[str, None]:

--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -1,3 +1,4 @@
+
 # import amberelectric
 from typing import Any, List, Mapping, Union
 from amberelectric.model.channel import ChannelType
@@ -13,7 +14,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import AmberDataService
 
-from .const import CONF_API_TOKEN, CONF_SITE_ID, LOGGER
+from .const import CONF_API_TOKEN, CONF_SITE_ID, LOGGER, DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION
 
 ATTRIBUTION = "Data provided by the Amber Electric pricing API"
@@ -39,6 +40,11 @@ class AmberPriceSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self) -> Union[str, None]:
         return self._platform_name + " - " + friendly_channel_type(self._channel_type) + " " + " Price"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the device"""
+        return "%s_%s_%s_%s" % (DOMAIN, self._platform_name, self._channel_type, "Price")
 
     @property
     def icon(self):
@@ -97,6 +103,11 @@ class AmberRenewablesSensor(CoordinatorEntity, SensorEntity):
         return self._platform_name + " - Renewables"
 
     @property
+    def unique_id(self):
+        """Return the unique id of the device"""
+        return "%s_%s_%s" % (DOMAIN, self._platform_name, "Renewables")
+
+    @property
     def icon(self):
         return "mdi:solar-power"
 
@@ -127,6 +138,11 @@ class AmberForecastSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self) -> Union[str, None]:
         return self._platform_name + " - " + friendly_channel_type(self._channel_type) + " " + " Forecast"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the device"""
+        return "%s_%s_%s_%s" % (DOMAIN, self._platform_name, self._channel_type, "Forecast")
 
     @property
     def icon(self):
@@ -187,6 +203,11 @@ class AmberPriceSpikeSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self) -> Union[str, None]:
         return self._platform_name + " - Price Spike"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the device"""
+        return "%s_%s_%s" % (DOMAIN, self._platform_name, "PriceSpike")        
 
     @property
     def state(self) -> Union[str, None]:


### PR DESCRIPTION
Sensors need a `unique_id` per [here](https://developers.home-assistant.io/docs/entity_registry_index/).