### PR TITLE
Add energy sensors

### DIFF
--- a/custom_components/amberelectric/manifest.json
+++ b/custom_components/amberelectric/manifest.json
@@ -8,7 +8,7 @@
         "@madpilot"
     ],
     "requirements": [
-        "amberelectric.py==1.0.0"
+        "amberelectric==1.0.0"
     ],
     "version": "1.0.0",
     "iot_class": "cloud_polling"


### PR DESCRIPTION
Adding new sensors that are compatible with the price tracking in the energy dashboard.

Why not change the existing ones? Amber uses c/kWh in the app, and the sensors here should do the same.